### PR TITLE
`mac` state var set to true for Mac and false for other platforms

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -30,11 +30,11 @@ class App extends Component {
   }
 
   componentDidMount() {
-    browserWindow.setHasShadow(false)
+    browserWindow.setDocumentEdited(true)
 
     this.setState({
-      mac: !browserWindow.hasShadow(),
-    }, () => browserWindow.setHasShadow(true))
+      mac: browserWindow.isDocumentEdited(),
+    })
   }
 
   addStarredProject = () => {


### PR DESCRIPTION
This fix uses a macOS only function on the browserWindow object. We set the window to appear edited, and then check if it is edited. If true then we're on a mac. Other platforms return false because they have no concept of edited windows.